### PR TITLE
Fix: Add npm install before running the CF build

### DIFF
--- a/cf/mta.yaml
+++ b/cf/mta.yaml
@@ -9,6 +9,7 @@ build-parameters:
   before-all:
     - builder: custom
       commands:
+        - npm install
         - npm run build:cf
 
 modules:


### PR DESCRIPTION
Problem: In a clean CI/CD environment the MBT (MTA build) won't work since the dependencies for the build:cf are not fulfilled.

How to reproduce: Use _clean_ local workspace with no prior "npm install" (not BAS!) or any CI tool and run the MBT. The build will fail with some dependency not being available (rimraf).

Fix: Adding an npm install in the before all section of the mta.yaml will make sure all required dependencies are available during build time.