### PR TITLE
fix: Add npm ci before running the npm build

### DIFF
--- a/cf/mta.yaml
+++ b/cf/mta.yaml
@@ -9,6 +9,7 @@ build-parameters:
   before-all:
     - builder: custom
       commands:
+        - npm ci
         - npm run build:cf
 
 modules:


### PR DESCRIPTION
**Problem**: In a clean CI/CD environment the MBT (MTA build tool) won't work since the dependencies for the build:cf script are not fulfilled.

**How to reproduce:** Use clean local workspace with no prior `npm install` (or any CI tool) and run the MBT. The build will fail with some dependency not being available (rimraf).

**Fix**: Adding an `npm ci` in the `before-all` section of the mta.yaml will make sure all required dependencies are available during build time.


Why `npm ci` instead of `npm install`? Clean install will make sure existing node_modules are removed. Additionally, `npm ci` will take into account the existing `package-lock.json` files as well. [1]


[1] https://docs.npmjs.com/cli/v10/commands/npm-ci?v=true