### PR TITLE
Switch to hana-client to allow calculated fields

### DIFF
--- a/cf/package-lock.json
+++ b/cf/package-lock.json
@@ -14,6 +14,7 @@
         "@sap-cloud-sdk/connectivity": "^4.5",
         "@sap-cloud-sdk/openapi": "^4.5",
         "@sap/cds": "~9.8",
+        "@sap/hana-client": "^2.28.20",
         "@sap/xsenv": "^6.1",
         "@sap/xssec": "^4.13"
       },
@@ -2638,6 +2639,33 @@
         "@sap/cds": ">=9",
         "eslint": "^9 || ^10"
       }
+    },
+    "node_modules/@sap/hana-client": {
+      "version": "2.28.20",
+      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.28.20.tgz",
+      "integrity": "sha512-SGOc83oh3UG3M0LuPLHebn/GGUakPMwGSZ9s89xzUB/mHvuOc284BwJ6UzxkwSY1iroH0hKHCTdIIB/vVVTDiw==",
+      "hasInstallScript": true,
+      "hasShrinkwrap": true,
+      "license": "SEE LICENSE IN developer-license-3_2.txt",
+      "dependencies": {
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@sap/hana-client/node_modules/debug": {
+      "version": "3.1.0",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@sap/hana-client/node_modules/ms": {
+      "version": "2.0.0",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/@sap/xsenv": {
       "version": "6.1.0",

--- a/cf/package.json
+++ b/cf/package.json
@@ -15,6 +15,7 @@
     "@sap-cloud-sdk/connectivity": "^4.5",
     "@sap-cloud-sdk/openapi": "^4.5",
     "@sap/cds": "~9.8",
+    "@sap/hana-client": "^2.28.20",
     "@sap/xsenv": "^6.1",
     "@sap/xssec": "^4.13"
   },


### PR DESCRIPTION
A current regression in `cds 9.7+` can not handle calculated columns that use literals in draft-enabled entities (used here: https://github.com/SAP-samples/btp-resource-consumption-monitor/blob/main/cf/srv/manageAlertsService.cds#L15).

A temporary solution is to switch from `hdb` to `@sap/hana-client` until `hdb` is fixed.

- [x] Fixes #100
- [x] Fixes #103 