### PR TITLE
Credit Burndown Tool Tip with Projection warning

### DIFF
--- a/workzone/cdm/cards/creditburndown/src/manifest.json
+++ b/workzone/cdm/cards/creditburndown/src/manifest.json
@@ -67,6 +67,7 @@
                 "path": "/value"
             },
             "chartType": "stacked_combination",
+            "tooltips": true,
             "chartProperties": {
                 "title": {
                     "visible": false
@@ -75,15 +76,71 @@
                     "visible": true
                 },
                 "plotArea": {
+                    "dataPointStyle": {
+                        "rules": [
+							{
+                                "dataContext": {
+									"Balance": {
+                                        "max": 50000
+									},
+                                    "Status": "Projection"
+                                },
+								"properties": {
+									"color": "red"
+								},
+								"displayName": "Projection / Balance Warning"
+							},
+                            {
+                                "dataContext": {
+									"Balance": {
+                                        "min": 50001
+									},
+                                    "Status": "Projection"
+                                },
+								"properties": {
+									"color": "lightgreen"
+								},
+								"displayName": "Projection / Balance"
+							},
+                            {
+                                "dataContext": {
+									"measureNames": "Contract",
+                                    "Status": "Projection"
+                                },
+								"properties": {
+									"color": "lightblue",
+                                    "lineType": "solid",
+                                    "lineColor": "lightblue"
+								},
+								"displayName": "Projection / Contract"
+							},
+                            {
+                                "dataContext": {
+									"measureNames": "Contract",
+                                    "Status": "Actual"
+                                },
+								"properties": {
+									"color": "darkblue",
+                                    "lineType": "solid",
+                                    "lineColor": "darkblue"
+								},
+								"displayName": "Actual / Contract"
+							},
+                            {
+                                "dataContext": {
+									"measureNames": "Balance",
+                                    "Status": "Actual"
+                                },
+								"properties": {
+									"color": "darkgreen"
+								},
+								"displayName": "Actual / Balance"
+							}
+                        ]
+                    },
                     "dataLabel": {
                         "visible": true
-                    },
-                    "colorPalette": [
-                        "darkgreen",
-                        "darkblue",
-                        "lightgreen",
-                        "lightblue"
-                    ]
+                    }
                 },
                 "categoryAxis": {
                     "title": {

--- a/workzone/cdm/cards/creditburndown/src/manifest.json
+++ b/workzone/cdm/cards/creditburndown/src/manifest.json
@@ -7,7 +7,7 @@
         "title": "{{title}}",
         "description": "{{description}}",
         "applicationVersion": {
-            "version": "2.0.0"
+            "version": "2.0.1"
         }
     },
     "sap.ui": {
@@ -27,30 +27,30 @@
         "header": {
             "type": "Numeric",
             "data": {
+                "name": "headerData",
                 "request": {
                     "url": "{{destinations.btprc-srv}}/odata/v4/contracts/Card_CreditBurnDownHeaders",
                     "withCredentials": true,
                     "parameters": {
                         "$filter": "globalAccountId eq '{filters>/account/selectedItem/additionalText}'"
                     }
-                },
-                "path": "/value/0"
+                }
             },
             "title": "{{title}}",
             "subTitle": "{{subtitle}}",
-            "details": "Phase start: {Credits_phaseStartDate}",
+            "details": "Phase start: {headerData>/value/0/Credits_phaseStartDate}",
             "mainIndicator": {
-                "number": "{= format.currency(${Credits_balance}, ${currency}, {currencyCode:true})}",
+                "number": "{= format.currency(${headerData>/value/0/Credits_balance}, ${headerData>/value/0/currency}, {currencyCode:true})}",
                 "state": "Good"
             },
             "sideIndicators": [
                 {
                     "title": "Contract Value",
-                    "number": "{= format.currency(${Credits_cloudCreditsForPhase}, ${currency}, {currencyCode:true})}"
+                    "number": "{= format.currency(${headerData>/value/0/Credits_cloudCreditsForPhase}, ${headerData>/value/0/currency}, {currencyCode:true})}"
                 },
                 {
                     "title": "Used in {month}",
-                    "number": "{= format.currency(${Measures_cloudCreditsCost}, ${currency}, {currencyCode:true})}"
+                    "number": "{= format.currency(${headerData>/value/0/Measures_cloudCreditsCost}, ${headerData>/value/0/currency}, {currencyCode:true})}"
                 }
             ],
             "actions": []
@@ -81,7 +81,7 @@
 							{
                                 "dataContext": {
 									"Balance": {
-                                        "max": 50000
+                                        "max": "{= parseFloat(${headerData>/value/0/Credits_cloudCreditsForPhase}) * ${parameters>/RemainingCreditsWarningPct/value} }"
 									},
                                     "Status": "Projection"
                                 },
@@ -93,7 +93,7 @@
                             {
                                 "dataContext": {
 									"Balance": {
-                                        "min": 50001
+                                        "min": "{= parseFloat(${headerData>/value/0/Credits_cloudCreditsForPhase}) * ${parameters>/RemainingCreditsWarningPct/value} + 0.01 }"
 									},
                                     "Status": "Projection"
                                 },
@@ -229,6 +229,12 @@
                 "btprc-srv": {
                     "name": "btprc-srv",
                     "defaultUrl": "/odata/v4/contracts/Card_CreditBurnDowns"
+                }
+            },
+            "parameters": {
+                "RemainingCreditsWarningPct": {
+                    "value": 0.25,
+                    "type": "number"
                 }
             }
         }


### PR DESCRIPTION
Add Tool Tip on hover to see the remaining balance, positive or negative, with an optional max/min value maintained in manifest.json for Creditburndown card, default at 50000.  Could not determine a way to make this a dynamic/config value and requires developer to adjust the default and republish to workzone.